### PR TITLE
Install libcroco and librsvg for the build

### DIFF
--- a/.github/workflows/build-pygtk.yaml
+++ b/.github/workflows/build-pygtk.yaml
@@ -57,6 +57,7 @@ jobs:
           ./vcpkg install python3:x86-windows --binarysource=$binarySource
           python -m ensurepip --upgrade
           python -m pip install virtualenv
+          ./vcpkg install libcroco:x86-windows librsvg:x86-windows --binarysource=$binarySource
           ./vcpkg install gobject-introspection:x86-windows --binarysource=$binarySource
           ./vcpkg install gtk3[introspection]:x86-windows --binarysource=$binarySource
 


### PR DESCRIPTION
@az0 When I went to update BleachBit to use the new wheel, I noticed these were missing.